### PR TITLE
feat: add danger to enforce conventional commits

### DIFF
--- a/.github/Dangerfile
+++ b/.github/Dangerfile
@@ -1,0 +1,48 @@
+# Ensure the PR has a meaningful title
+fail("PR title must not be empty!") if github.pr_title.strip.empty?
+
+# Ensure PRs have a description
+fail("Please add a description to this PR") if github.pr_body.strip.length < 10
+
+# Warn if a PR modifies more than 500 lines
+warn("This PR is quite large. Consider breaking it into smaller PRs.") if git.lines_of_code > 500
+
+# Fail if a PR does not reference an issue (e.g., #123 in title)
+fail("This PR must reference an issue (e.g., #123 in the title)") unless github.pr_title =~ /#[0-9]+/
+
+# Warn if the PR does not have an assigned reviewer
+warn("This PR does not have a reviewer assigned.") if github.reviewers.empty?
+
+# Ensure commits follow Conventional Commits and additional formatting rules
+git.commits.each do |commit|
+  # Conventional Commits format
+  unless commit.message =~ /^(feat|fix|chore|docs|style|refactor|test)(\(\w+\))?: .+/
+    fail("Commit message '#{commit.message}' does not follow Conventional Commits format.")
+  end
+
+  lines = commit.message.split("\n")
+
+  # Ensure the title is a maximum of 50 characters
+  title = lines[0]
+  if title.length > 50
+    fail("Commit title '#{title}' exceeds 50 characters.")
+  end
+
+  # Ensure there is an empty line between title and description
+  if lines.length > 1 && !lines[1].strip.empty?
+    fail("Commit message must have an empty line between title and description.")
+  end
+
+  # Ensure the description has at least 5 characters
+  description = lines[2..].join("\n").strip if lines.length > 2
+  if description && description.length < 5
+    fail("Commit description must be at least 5 characters long.")
+  end
+
+  # Ensure each line in the description is not more than 72 characters
+  lines[2..].each do |line|
+    if line.length > 72
+      fail("Commit description line exceeds 72 characters: '#{line}'.")
+    end
+  end
+end

--- a/.github/Gemfile
+++ b/.github/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "danger"

--- a/.github/workflows/conventionalCommits.yml
+++ b/.github/workflows/conventionalCommits.yml
@@ -1,0 +1,17 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          allowed-commit-types: "feat,fix,chore,docs,refactor,test,style"

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,30 @@
+name: Danger
+
+on:
+  pull_request:
+    branches:
+      - main
+      
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    if: github.event_name  == 'pull_request'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - uses: actions/cache@v4
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('.github/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - uses: MeilCli/danger-action@v6
+      with:
+        plugins_file: '.github/Gemfile'
+        install_path: 'vendor/bundle'
+        danger_file: '.github/Dangerfile'
+        danger_id: 'danger-pr'
+      env:
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ El objetivo principal es crear una plataforma sencilla de utilizar para consulta
 - Victor Manuel Tellez Amezcua
 - Jose Santiago Oseguera García
 - Rodrigo López Coronado
+- Luis Antonio Cuaquentzi Avendaño
 
 # Instrucciones para ejecutar el proyecto
 
@@ -599,3 +600,31 @@ Recomendamos utilizar **Postman** para realizar las pruebas
     - `500`: Error al eliminar la reservación.
 
 Si todo salió correctamente, debe salir un código 200 y un mensaje de éxito y/o mostrar el contenido correspondiente. 
+
+## Commit Message Guidelines
+
+This repository follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. All commit messages **must** follow this format:
+
+`<type>(<optional scope>): <description>`
+
+`<optional body>`
+
+`<optional footer>`
+
+Valid Commit Examples
+- feat: add user authentication
+- fix: resolve issue with login timeout
+- docs: update API documentation
+- chore(deps): update dependencies
+- feat(api): send an email to the customer when a product is shipped
+
+Commit Types
+- feat → A new feature
+- fix → A bug fix
+- docs → Documentation updates
+- chore → Maintenance tasks (e.g., dependency updates)
+- refactor → Code changes that don’t fix bugs or add features
+- test → Adding or modifying tests
+- style → Formatting changes (whitespace, linting, etc.)
+
+Pull requests with commits that do not follow this format will be rejected by automated checks.


### PR DESCRIPTION
- Configured Dangerfile and GitHub Actions to automatically enforce conventional commit format.
- Set up commit message validation on pull requests to the `main` branch.
- Added configuration for commit types: `feat`, `fix`.
- Updated README to include commit message guidelines.

BREAKING CHANGE: This setup introduces a mandatory commit message format that must be followed for all PRs to `main`.